### PR TITLE
Requester demo for feature phone support

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -3,6 +3,7 @@ import sys
 
 import toopher
 from toopher import ToopherApiError
+import argparse
 
 DEFAULT_USERNAME = 'demo@toopher.com'
 DEFAULT_TERMINAL_NAME = 'my computer'
@@ -12,6 +13,13 @@ def print_sep(char='-'):
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Toopher Library Usage Demo')
+    parser.add_argument('-ff', dest='feature_phone', action='store_true',
+                    help='Use Feature-Phone mode (SMS messages instead of Smartphone push)')
+    parser.add_argument('--sms-inband-reply', dest='sms_inband_reply', action='store_true',
+                    help='Send a OTP to user over SMS for entry through the website (instead of prompting them to reply via SMS).  This option only makes sense if -ff is also supplied.')
+    args = parser.parse_args()
+
     print_sep('=')
     print 'Library Usage Demo'
     print_sep('=')
@@ -29,16 +37,28 @@ if __name__ == '__main__':
         while not secret:
             secret = raw_input('TOOPHER_CONSUMER_SECRET=')
             
+    if os.environ.get('TOOPHER_BASE_URL'):
+        toopher.BASE_URL = os.environ.get('TOOPHER_BASE_URL').rstrip('/')
+
     api = toopher.ToopherApi(key, secret)
     
     while True:
         print 'Step 1: Pair requester with phone'
         print_sep('-')
-        print 'Pairing phrases are generated on the mobile app'
-        pairing_phrase = raw_input('Enter pairing phrase: ')
-        while not pairing_phrase:
-            print 'Please enter a pairing phrase to continue'
-            pairing_phrase = raw_input('Enter pairing phrase: ')
+        if args.feature_phone:
+            pair_func = api.pair_sms
+            pair_help = 'Non-US numbers should start with a "+" and include the country code.'
+            pair_type = 'mobile number'
+        else:
+            pair_func = api.pair
+            pair_help = 'Pairing phrases are generated on the mobile app'
+            pair_type = 'pairing phrase'
+        
+        print pair_help
+        pairing_key = raw_input('Enter {0}: '.format(pair_type))
+        while not pairing_key:
+            print 'Please enter a {0} to continue'.format(pair_type)
+            pairing_key = raw_input('Enter {0}: '.format(pair_type))
             
         user_name = raw_input('Enter a username for this pairing [%s]: ' % DEFAULT_USERNAME)
         if not user_name:
@@ -47,7 +67,7 @@ if __name__ == '__main__':
         print 'Sending pairing request...'
         
         try:
-            pairing_status = api.pair(pairing_phrase, user_name)
+            pairing_status = pair_func(pairing_key, user_name)
             pairing_id = pairing_status.id
             break
         except ToopherApiError, e:
@@ -80,18 +100,25 @@ if __name__ == '__main__':
         print 'Sending authentication request...'
         
         try:
-            request_status = api.authenticate(pairing_id, terminal_name)
+            request_status = api.authenticate(pairing_id, terminal_name, use_sms_inband_reply=args.sms_inband_reply)
             request_id = request_status.id
         except ToopherApiError, e:
             print 'Error initiating authentication (reason: %s)' % e
             continue
         
         while True:
-            raw_input('Response to authentication request on phone (if prompted) and then press return to continue.')
+            if args.sms_inband_reply:
+                otp = raw_input('Enter the One-Time-Password that was sent to your phone to continue: ')
+            else:
+                otp = None
+                raw_input('Response to authentication request on phone (if prompted) and then press return to continue.')
             print 'Checking status of authentication request...'
             
             try:
-                request_status = api.get_authentication_status(request_id)
+                if otp:
+                    request_status = api.authenticate_with_otp(request_id, otp)
+                else:
+                    request_status = api.get_authentication_status(request_id)
             except ToopherApiError, e:
                 print 'Could not check authentication status (reason: %s)' % e
                 continue

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -17,6 +17,17 @@ class ToopherApi(object):
         
         result = self._request(uri, "POST", params)
         return PairingStatus(result)
+
+    def pair_sms(self, phone_number, user_name, phone_country=None):
+        uri = BASE_URL + "/pairings/create/sms"
+        params = {'phone_number': phone_number,
+                  'user_name': user_name}
+       
+        if phone_country:
+            params['phone_country'] = phone_country
+
+        result = self._request(uri, "POST", params)
+        return PairingStatus(result)
         
     def get_pairing_status(self, pairing_id):
         uri = BASE_URL + "/pairings/" + pairing_id
@@ -24,10 +35,11 @@ class ToopherApi(object):
         result = self._request(uri, "GET")
         return PairingStatus(result)
 
-    def authenticate(self, pairing_id, terminal_name, action_name=None):
+    def authenticate(self, pairing_id, terminal_name, action_name=None, use_sms_inband_reply=False):
         uri = BASE_URL + "/authentication_requests/initiate"
         params = {'pairing_id': pairing_id,
-                  'terminal_name': terminal_name}
+                  'terminal_name': terminal_name,
+                  'use_sms_inband_reply': use_sms_inband_reply}
         if action_name:
             params['action_name'] = action_name
             
@@ -38,6 +50,12 @@ class ToopherApi(object):
         uri = BASE_URL + "/authentication_requests/" + authentication_request_id
         
         result = self._request(uri, "GET")
+        return AuthenticationStatus(result)
+
+    def authenticate_with_otp(self, authentication_request_id, otp):
+        uri = BASE_URL + "/authentication_requests/" + authentication_request_id + '/otp_auth'
+        params = {'otp' : otp}
+        result = self._request(uri, "POST", params)
         return AuthenticationStatus(result)
     
     def _request(self, uri, method, params=None):


### PR DESCRIPTION
Updates the python demo to show how to use Toopher API to authenticate with "Feature Phones" (aka dumbphones).  Feature-phone demo is accessed by running the demo.py script with the -ff command-line argument.
