### PR TITLE
Add support for challenge and automation_allowed to toopher-python

### DIFF
--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -24,7 +24,7 @@ class ToopherApi(object):
         result = self._request(uri, "GET")
         return PairingStatus(result)
 
-    def authenticate(self, pairing_id, terminal_name, action_name=None, automation_allowed=None, challenge_required=None):
+    def authenticate(self, pairing_id, terminal_name, action_name=None, automation_allowed=True, challenge_required=False):
         uri = BASE_URL + "/authentication_requests/initiate"
         params = {'pairing_id': pairing_id,
                   'terminal_name': terminal_name}

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -33,7 +33,7 @@ class ToopherApi(object):
         if isinstance(automation_allowed, bool):
             params['automation_allowed'] = automation_allowed
         if isinstance(challenge_required, bool):
-           params['challenge_required'] = challenge_required
+            params['challenge_required'] = challenge_required
         result = self._request(uri, "POST", params)
         return AuthenticationStatus(result)
 

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -24,13 +24,16 @@ class ToopherApi(object):
         result = self._request(uri, "GET")
         return PairingStatus(result)
 
-    def authenticate(self, pairing_id, terminal_name, action_name=None):
+    def authenticate(self, pairing_id, terminal_name, action_name=None, automation_allowed=None, challenge_required=None):
         uri = BASE_URL + "/authentication_requests/initiate"
         params = {'pairing_id': pairing_id,
                   'terminal_name': terminal_name}
         if action_name:
             params['action_name'] = action_name
-            
+        if isinstance(automation_allowed, bool):
+            params['automation_allowed'] = automation_allowed
+        if isinstance(challenge_required, bool):
+           params['challenge_required'] = challenge_required
         result = self._request(uri, "POST", params)
         return AuthenticationStatus(result)
 


### PR DESCRIPTION
Why? So that requesters (like SSH) can disallow automation, and require gesture challenges.
