### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+# command to install dependencies
+install:
+#  - pip install -r requirements.txt --use-mirrors
+  - pip install toopher
+# command to run tests
+script: python tests.py

--- a/tests.py
+++ b/tests.py
@@ -1,1 +1,15 @@
-# Placeholder for tests currently being written
+import unittest
+import os
+
+import toopher
+
+class ToopherTests(unittest.TestCase):
+    def test_nothing(self):
+        pass
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
I've added a basic Travis CI configuration file for Python and a simple test (that always passes) to ensure Travis works.

For now, I configured Travis to simply install the toopher package, but in the future we may want to move dependencies into a `requirements.txt` file for Pip. I've commented out that line in the `.travis.yml` for reference.

For more, see the [Travis CI Getting Started Guide](http://about.travis-ci.org/docs/user/getting-started/).
