### PR TITLE
Updates toopher-python API for new features

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import uuid
 
 import toopher
 from toopher import ToopherApiError
@@ -29,6 +30,9 @@ if __name__ == '__main__':
         while not secret:
             secret = raw_input('TOOPHER_CONSUMER_SECRET=')
             
+    if os.environ.get('TOOPHER_BASE_URL'):
+        toopher.BASE_URL = os.environ.get('TOOPHER_BASE_URL').rstrip('/')
+
     api = toopher.ToopherApi(key, secret)
     
     while True:
@@ -69,6 +73,8 @@ if __name__ == '__main__':
             raise
             print 'Could not check pairing status (reason: %s)' % e
             
+    terminal_extras = {}
+
     while True:
         print 'Step 2: Authenticate log in'
         print_sep()
@@ -76,11 +82,16 @@ if __name__ == '__main__':
         terminal_name = raw_input('Enter a terminal name for this authentication request [%s]: ' % DEFAULT_TERMINAL_NAME)
         if not terminal_name:
             terminal_name = DEFAULT_TERMINAL_NAME
+
+        if terminal_name in terminal_extras:
+            terminal_extra = terminal_extras[terminal_name]
+        else:
+            terminal_extra = terminal_extras[terminal_name] = uuid.uuid4()
             
         print 'Sending authentication request...'
         
         try:
-            request_status = api.authenticate(pairing_id, terminal_name)
+            request_status = api.authenticate(pairing_id, terminal_name, terminal_name_extra=terminal_extra)
             request_id = request_status.id
         except ToopherApiError, e:
             print 'Error initiating authentication (reason: %s)' % e

--- a/demo.py
+++ b/demo.py
@@ -30,10 +30,7 @@ if __name__ == '__main__':
         while not secret:
             secret = raw_input('TOOPHER_CONSUMER_SECRET=')
             
-    if os.environ.get('TOOPHER_BASE_URL'):
-        toopher.BASE_URL = os.environ.get('TOOPHER_BASE_URL').rstrip('/')
-
-    api = toopher.ToopherApi(key, secret)
+    api = toopher.ToopherApi(key, secret, os.environ.get('TOOPHER_BASE_URL'))
     
     while True:
         print 'Step 1: Pair requester with phone'

--- a/tests.py
+++ b/tests.py
@@ -1,11 +1,168 @@
 import unittest
 import os
+import urlparse
 
 import toopher
 
+class HttpClientMock(object):
+    def __init__(self, paths):
+        self.paths = paths
+
+    def request(self, uri, method, data):
+        self.last_called_uri = uri
+        self.last_called_method = method
+        self.last_called_data = urlparse.parse_qs(data)
+
+        if uri in self.paths:
+            return self.paths[uri]
+        else:
+            return {'status':400}, None
+
+
 class ToopherTests(unittest.TestCase):
-    def test_nothing(self):
-        pass
+    def test_constructor(self):
+        with self.assertRaises(TypeError):
+            api = toopher.ToopherApi()
+
+        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+
+    def test_create_pairing(self):
+        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api.client = HttpClientMock({
+            'http://testonly/pairings/create':(
+                {'status':'200'},
+                '{"id":"1", "enabled":true, "user":{"id":"1","name":"some user"}}'
+                )
+            })
+        pairing = api.pair('awkward turtle', 'some user')
+
+        self.assertEqual(api.client.last_called_method, 'POST')
+        self.assertEqual(api.client.last_called_data['pairing_phrase'], ['awkward turtle'])
+        with self.assertRaises(KeyError):
+            self.assertEqual(api.client.last_called_data['test_param'], ['42'])
+    
+    def test_pairing_status(self):
+        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api.client = HttpClientMock({
+            'http://testonly/pairings/1':(
+                {'status':'200'},
+                '{"id":"1", "enabled":true, "user":{"id":"1","name":"some user"}}'
+                )
+            })
+        pairing = api.get_pairing_status('1')
+        self.assertEqual(api.client.last_called_method, 'GET')
+
+        self.assertEqual(pairing.id, '1')
+        self.assertEqual(pairing.user_name, 'some user')
+        self.assertEqual(pairing.user_id, '1')
+        self.assertTrue(pairing.enabled)
+
+        with self.assertRaises(KeyError):
+            foo = pairing.random_key
+
+    def test_create_authentication_request(self):
+        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api.client = HttpClientMock({
+            'http://testonly/authentication_requests/initiate':(
+                {'status':'200'},
+                '{"id":"1", "pending":false, "granted":true, "automated":false, "reason":"its a test", "terminal":{"id":"1", "name":"test terminal"}}'
+                )
+            })
+        auth_request = api.authenticate('1', 'test terminal')
+        self.assertEqual(api.client.last_called_method, 'POST')
+        self.assertEqual(api.client.last_called_data['pairing_id'], ['1'])
+        self.assertEqual(api.client.last_called_data['terminal_name'], ['test terminal'])
+        with self.assertRaises(KeyError):
+            self.assertEqual(api.client.last_called_data['test_param'], ['42'])
+
+
+    def test_authentication_status(self):
+        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api.client = HttpClientMock({
+            'http://testonly/authentication_requests/1':(
+                {'status':'200'},
+                '{"id":"1", "pending":false, "granted":true, "automated":false, "reason":"its a test", "terminal":{"id":"1", "name":"test terminal"}}'
+                )
+            })
+        auth_request = api.get_authentication_status('1')
+        self.assertEqual(api.client.last_called_method, 'GET')
+        self.assertEqual(auth_request.id, '1')
+        self.assertFalse(auth_request.pending, False)
+        self.assertTrue(auth_request.granted)
+        self.assertFalse(auth_request.automated)
+        self.assertEqual(auth_request.reason, 'its a test')
+        self.assertEqual(auth_request.terminal_id, '1')
+        self.assertEqual(auth_request.terminal_name, 'test terminal')
+
+        with self.assertRaises(KeyError):
+            foo = auth_request.random_key
+
+    def test_pass_arbitrary_parameters_on_pair(self):
+        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api.client = HttpClientMock({
+            'http://testonly/pairings/create':(
+                {'status':'200'},
+                '{"id":"1", "enabled":true, "user":{"id":"1","name":"some user"}}'
+                )
+            })
+        pairing = api.pair('awkward turtle', 'some user', test_param='42')
+
+        self.assertEqual(api.client.last_called_method, 'POST')
+        self.assertEqual(api.client.last_called_data['pairing_phrase'], ['awkward turtle'])
+        self.assertEqual(api.client.last_called_data['test_param'], ['42'])
+
+    def test_pass_arbitrary_parameters_on_authenticate(self):
+        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api.client = HttpClientMock({
+            'http://testonly/authentication_requests/initiate':(
+                {'status':'200'},
+                '{"id":"1", "pending":false, "granted":true, "automated":false, "reason":"its a test", "terminal":{"id":"1", "name":"test terminal"}}'
+                )
+            })
+        auth_request = api.authenticate('1', 'test terminal', test_param='42')
+        self.assertEqual(api.client.last_called_method, 'POST')
+        self.assertEqual(api.client.last_called_data['pairing_id'], ['1'])
+        self.assertEqual(api.client.last_called_data['terminal_name'], ['test terminal'])
+        self.assertEqual(api.client.last_called_data['test_param'], ['42'])
+
+    def test_access_arbitrary_keys_in_pairing_status(self):
+        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api.client = HttpClientMock({
+            'http://testonly/pairings/1':(
+                {'status':'200'},
+                '{"id":"1", "enabled":true, "user":{"id":"1","name":"some user"}, "random_key":"84"}'
+                )
+            })
+        pairing = api.get_pairing_status('1')
+        self.assertEqual(api.client.last_called_method, 'GET')
+
+        self.assertEqual(pairing.id, '1')
+        self.assertEqual(pairing.user_name, 'some user')
+        self.assertEqual(pairing.user_id, '1')
+        self.assertTrue(pairing.enabled)
+
+        self.assertEqual(pairing.random_key, "84")
+
+
+    def test_access_arbitrary_keys_in_authentication_status(self):
+        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api.client = HttpClientMock({
+            'http://testonly/authentication_requests/1':(
+                {'status':'200'},
+                '{"id":"1", "pending":false, "granted":true, "automated":false, "reason":"its a test", "terminal":{"id":"1", "name":"test terminal"}, "random_key":"84"}'
+                )
+            })
+        auth_request = api.get_authentication_status('1')
+        self.assertEqual(api.client.last_called_method, 'GET')
+        self.assertEqual(auth_request.id, '1')
+        self.assertFalse(auth_request.pending, False)
+        self.assertTrue(auth_request.granted)
+        self.assertFalse(auth_request.automated)
+        self.assertEqual(auth_request.reason, 'its a test')
+        self.assertEqual(auth_request.terminal_id, '1')
+        self.assertEqual(auth_request.terminal_name, 'test terminal')
+
+        self.assertEqual(auth_request.random_key, "84")
 
 def main():
     unittest.main()

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -2,16 +2,18 @@ import urllib
 import json
 import oauth2
 import os
-BASE_URL = "https://api.toopher.com/v1"
+DEFAULT_BASE_URL = "https://api.toopher.com/v1"
 
 
 class ToopherApi(object):
-    def __init__(self, key, secret):
+    def __init__(self, key, secret, api_url=None):
         self.client = oauth2.Client(oauth2.Consumer(key, secret))
         self.client.ca_certs = os.path.join(os.path.dirname(os.path.abspath(__file__)), "toopher.pem")
+        base_url = api_url if api_url else DEFAULT_BASE_URL
+        self.base_url = base_url.rstrip('/')
 
     def pair(self, pairing_phrase, user_name, **kwargs):
-        uri = BASE_URL + "/pairings/create"
+        uri = self.base_url + "/pairings/create"
         params = {'pairing_phrase': pairing_phrase,
                   'user_name': user_name}
 
@@ -21,13 +23,13 @@ class ToopherApi(object):
         return PairingStatus(result)
         
     def get_pairing_status(self, pairing_id):
-        uri = BASE_URL + "/pairings/" + pairing_id
+        uri = self.base_url + "/pairings/" + pairing_id
         
         result = self._request(uri, "GET")
         return PairingStatus(result)
 
     def authenticate(self, pairing_id, terminal_name, action_name=None, **kwargs):
-        uri = BASE_URL + "/authentication_requests/initiate"
+        uri = self.base_url + "/authentication_requests/initiate"
         params = {'pairing_id': pairing_id,
                   'terminal_name': terminal_name}
         if action_name:
@@ -39,7 +41,7 @@ class ToopherApi(object):
         return AuthenticationStatus(result)
 
     def get_authentication_status(self, authentication_request_id):
-        uri = BASE_URL + "/authentication_requests/" + authentication_request_id
+        uri = self.base_url + "/authentication_requests/" + authentication_request_id
         
         result = self._request(uri, "GET")
         return AuthenticationStatus(result)

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -74,8 +74,8 @@ class PairingStatus(object):
             user = json_response['user']
             self.user_id = user['id']
             self.user_name = user['name']
-        except Exception:
-            raise ToopherApiError("Could not parse pairing status from response")
+        except Exception as e:
+            raise ToopherApiError("Could not parse pairing status from response" + e.message)
 
         self._raw_data = json_response
         
@@ -83,7 +83,7 @@ class PairingStatus(object):
         return self.enabled
 
     def __getattr__(self, name):
-        return self._raw_data.get(name)
+        return self._raw_data[name]
 
 
 class AuthenticationStatus(object):
@@ -107,7 +107,7 @@ class AuthenticationStatus(object):
         return self.granted
 
     def __getattr__(self, name):
-        return self._raw_data.get(name)
+        return self._raw_data[name]
 
 
 class ToopherApiError(Exception): pass


### PR DESCRIPTION
Allow arbitrary parameters to be passed to API using **kwargs.
Access raw API response for Pairing and Auth using **getattr**
Use terminal_name_extra in demo.py
