### PR TITLE
Add version constant to library, bump version, and test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='toopher',
-    version='1.0.5',
+    version='1.0.6',
     author='Toopher, Inc.',
     author_email='support@toopher.com',
     url='https://dev.toopher.com',

--- a/tests.py
+++ b/tests.py
@@ -8,10 +8,11 @@ class HttpClientMock(object):
     def __init__(self, paths):
         self.paths = paths
 
-    def request(self, uri, method, data):
+    def request(self, uri, method, data, headers):
         self.last_called_uri = uri
         self.last_called_method = method
         self.last_called_data = urlparse.parse_qs(data)
+        self.last_called_headers = headers
 
         if uri in self.paths:
             return self.paths[uri]

--- a/tests.py
+++ b/tests.py
@@ -28,7 +28,10 @@ class ToopherTests(unittest.TestCase):
         api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
 
     def test_version_number_in_library(self):
-        self.assertGreaterEqual(toopher.VERSION, "1.0.6")
+        major, minor, patch = toopher.VERSION.split('.')
+        self.assertGreaterEqual(int(major), 1)
+        self.assertGreaterEqual(int(minor), 0)
+        self.assertGreaterEqual(int(patch), 0)
 
     def test_version_number_in_setup(self):
         ''' Ensure that the setup.py file has the same version number as the toopher/__init__.py file '''

--- a/tests.py
+++ b/tests.py
@@ -26,6 +26,17 @@ class ToopherTests(unittest.TestCase):
 
         api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
 
+    def test_version_number_in_library(self):
+        self.assertGreaterEqual(toopher.VERSION, "1.0.6")
+
+    def test_version_number_in_setup(self):
+        ''' Ensure that the setup.py file has the same version number as the toopher/__init__.py file '''
+        for line in open('setup.py'):
+            if "version" in line:
+                # in setup.py the version is written as "version='1.0.6'," so we need to remove version=' and ',
+                version_number = line.strip().replace("version='", "").replace("',", "")
+                self.assertEqual(version_number, toopher.VERSION)
+
     def test_create_pairing(self):
         api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
         api.client = HttpClientMock({
@@ -40,7 +51,7 @@ class ToopherTests(unittest.TestCase):
         self.assertEqual(api.client.last_called_data['pairing_phrase'], ['awkward turtle'])
         with self.assertRaises(KeyError):
             self.assertEqual(api.client.last_called_data['test_param'], ['42'])
-    
+
     def test_pairing_status(self):
         api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
         api.client = HttpClientMock({
@@ -74,7 +85,6 @@ class ToopherTests(unittest.TestCase):
         self.assertEqual(api.client.last_called_data['terminal_name'], ['test terminal'])
         with self.assertRaises(KeyError):
             self.assertEqual(api.client.last_called_data['test_param'], ['42'])
-
 
     def test_authentication_status(self):
         api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
@@ -142,7 +152,6 @@ class ToopherTests(unittest.TestCase):
         self.assertTrue(pairing.enabled)
 
         self.assertEqual(pairing.random_key, "84")
-
 
     def test_access_arbitrary_keys_in_authentication_status(self):
         api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -19,7 +19,7 @@ class ToopherApi(object):
                   'user_name': user_name}
 
         params.update(kwargs)
-        
+
         result = self._request(uri, "POST", params)
         return PairingStatus(result)
 
@@ -27,16 +27,16 @@ class ToopherApi(object):
         uri = BASE_URL + "/pairings/create/sms"
         params = {'phone_number': phone_number,
                   'user_name': user_name}
-       
+
         if phone_country:
             params['phone_country'] = phone_country
 
         result = self._request(uri, "POST", params)
         return PairingStatus(result)
-        
+
     def get_pairing_status(self, pairing_id):
         uri = self.base_url + "/pairings/" + pairing_id
-        
+
         result = self._request(uri, "GET")
         return PairingStatus(result)
 
@@ -48,13 +48,13 @@ class ToopherApi(object):
             params['action_name'] = action_name
 
         params.update(kwargs)
-            
+
         result = self._request(uri, "POST", params)
         return AuthenticationStatus(result)
 
     def get_authentication_status(self, authentication_request_id):
         uri = self.base_url + "/authentication_requests/" + authentication_request_id
-        
+
         result = self._request(uri, "GET")
         return AuthenticationStatus(result)
 
@@ -63,23 +63,24 @@ class ToopherApi(object):
         params = {'otp' : otp}
         result = self._request(uri, "POST", params)
         return AuthenticationStatus(result)
-    
+
     def _request(self, uri, method, params=None):
         data = urllib.urlencode(params or {})
-        
-        resp, content = self.client.request(uri, method, data)
+        header_data = {'User-Agent':'Toopher-Python/{}'.format(VERSION)}
+
+        resp, content = self.client.request(uri, method, data, headers=header_data)
         if resp['status'] != '200':
             try:
                 error_message = json.loads(content)['error_message']
             except Exception:
                 error_message = content
             raise ToopherApiError(error_message)
-        
+
         try:
             result = json.loads(content)
         except Exception, e:
             raise ToopherApiError("Response from server could not be decoded as JSON: %s" % e)
-        
+
         return result
 
 
@@ -88,7 +89,7 @@ class PairingStatus(object):
         try:
             self.id = json_response['id']
             self.enabled = json_response['enabled']
-            
+
             user = json_response['user']
             self.user_id = user['id']
             self.user_name = user['name']
@@ -96,7 +97,7 @@ class PairingStatus(object):
             raise ToopherApiError("Could not parse pairing status from response" + e.message)
 
         self._raw_data = json_response
-        
+
     def __nonzero__(self):
         return self.enabled
 
@@ -112,7 +113,7 @@ class AuthenticationStatus(object):
             self.granted = json_response['granted']
             self.automated = json_response['automated']
             self.reason = json_response['reason']
-            
+
             terminal = json_response['terminal']
             self.terminal_id = terminal['id']
             self.terminal_name = terminal['name']
@@ -129,3 +130,4 @@ class AuthenticationStatus(object):
 
 
 class ToopherApiError(Exception): pass
+

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -2,6 +2,7 @@ import urllib
 import json
 import oauth2
 import os
+import sys
 DEFAULT_BASE_URL = "https://api.toopher.com/v1"
 VERSION = "1.0.6"
 
@@ -66,7 +67,7 @@ class ToopherApi(object):
 
     def _request(self, uri, method, params=None):
         data = urllib.urlencode(params or {})
-        header_data = {'User-Agent':'Toopher-Python/{}'.format(VERSION)}
+        header_data = {'User-Agent':'Toopher-Python/{} (Python {})'.format(VERSION, sys.version.split()[0])}
 
         resp, content = self.client.request(uri, method, data, headers=header_data)
         if resp['status'] != '200':

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -3,6 +3,7 @@ import json
 import oauth2
 import os
 DEFAULT_BASE_URL = "https://api.toopher.com/v1"
+VERSION = "1.0.6"
 
 
 class ToopherApi(object):


### PR DESCRIPTION
This pull request will add a `VERSION` constant to the library, making it easier to debug (e.g., _"before going any further, what is your `toopher.VERSION`?"_). 

I wrote a test to ensure that the version number exists in the library and is greater than or equal to this version, `1.0.6`, and wrote another test to ensure that the version number from the library matches the version number in the `setup.py` file used by PyPy/pip.
