### PR TITLE
Zero-Storage II: The Lost Years

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "2.7"
 # command to install dependencies
 install:
-#  - pip install -r requirements.txt --use-mirrors
-  - pip install toopher
+  - pip install -r requirements.txt --use-mirrors
 # command to run tests
 script: python tests.py

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ except UnknownTerminalError:
     # This user has not assigned a "Friendly Name" to this terminal identifier.
     # Prompt them to enter a terminal name, then submit that "friendly name" to
     # the Toopher API:
-    #   api.assign_user_friendly_name_to_terminal(user_name, terminal_friendly_name, terminal_identifier)
+    #   api.create_user_terminal(user_name, terminal_name, requester_terminal_id)
     # Afterwards, re-try authentication
 except PairingDeactivatedError:
     # this user does not have an active pairing,

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ try:
     # optimistically try to authenticate against Toopher API with username and a Terminal Identifier
     # Terminal Identifer is typically a randomly generated secure browser cookie.  It does not
     # need to be human-readable
-    auth = api.authenticate_by_user_name("username@yourservice.com", "<terminal identifier>")
+    auth = api.authenticate_by_user_name(user_name, requester_terminal_id)
 
     # if you got here, everything is good!  poll the auth request status as described above
     # there are four distinct errors ToopherAPI can return if it needs more data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+coverage==3.7
+nose==1.3.0
 oauthlib==0.6.0
 requests==2.0.1
 requests-oauthlib==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+oauthlib==0.6.0
+requests==2.0.1
+requests-oauthlib==0.4.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='toopher',
-    version='1.0.6',
+    version='1.1.0',
     author='Toopher, Inc.',
     author_email='support@toopher.com',
     url='https://dev.toopher.com',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name='toopher',
     version='1.1.0',
     author='Toopher, Inc.',
-    author_email='support@toopher.com',
+    author_email='dev@toopher.com',
     url='https://dev.toopher.com',
     description='Wrapper library for the Toopher authentication API',
     classifiers=[
@@ -18,9 +18,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         ],
     packages=['toopher'],
-    package_data = {'toopher': ['toopher.pem']},
+    package_data={'toopher': ['toopher.pem']},
     test_suite='tests',
-    install_requires=[
-        'oauth2',
-        ]
+    install_requires=['requests-oauthlib>=0.4.0']
 )

--- a/tests.py
+++ b/tests.py
@@ -234,6 +234,25 @@ class ToopherTests(unittest.TestCase):
         with self.assertRaises(toopher.PairingDeactivatedError):
             auth_request = api.authenticate_by_user_name('user', 'terminal name')
 
+class ddict(dict):
+    def __getitem__(self, key):
+        try:
+            value = super(ddict, self).__getitem__(key)
+            return value
+        except KeyError as e:
+            return ddict()
+
+class AuthenticationStatusTests(unittest.TestCase):
+    def test_nonzero_when_granted(self):
+        response = ddict()
+        response['granted'] = True
+        allowed = toopher.AuthenticationStatus(response)
+        self.assertTrue(allowed)
+
+        response['granted'] = False
+        denied = toopher.AuthenticationStatus(response)
+        self.assertFalse(denied)
+
 def main():
     unittest.main()
 

--- a/tests.py
+++ b/tests.py
@@ -176,6 +176,13 @@ class ToopherTests(unittest.TestCase):
 
         self.assertEqual(auth_request.random_key, "84")
 
+class ZeroStorageTests(unittest.TestCase):
+    def test_create_user_terminal(self):
+        api = toopher.ToopherApi('key', 'secret')
+        api.client = HttpClientMock({'user_terminals/create': (200, '{}')})
+
+        api.create_user_terminal('user_name', 'terminal_name', 'requester_terminal_id')
+
     def test_disabled_user_raises_correct_error(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
@@ -225,13 +232,6 @@ class ToopherTests(unittest.TestCase):
 
         with self.assertRaises(toopher.PairingDeactivatedError):
             auth_request = api.authenticate_by_user_name('user', 'terminal name')
-
-class ZeroStorageTests(unittest.TestCase):
-    def test_create_user_terminal(self):
-        api = toopher.ToopherApi('key', 'secret')
-        api.client = HttpClientMock({'user_terminals/create': (200, '{}')})
-
-        api.create_user_terminal('user_name', 'terminal_name', 'requester_terminal_id')
 
 class ddict(dict):
     def __getitem__(self, key):

--- a/tests.py
+++ b/tests.py
@@ -17,12 +17,12 @@ class HttpClientMock(object):
         if uri in self.paths:
             return ResponseMock(self.paths[uri])
         else:
-            return {'status': 400}, ''
+            return ResponseMock((400, '{}'))
 
 class ResponseMock(requests.Response):
     def __init__(self, response):
         self.encoding = 'utf-8'
-        self.status_code = int(response[0]['status'])
+        self.status_code = int(response[0])
         self._content = response[1]
 
 class ToopherTests(unittest.TestCase):
@@ -51,8 +51,7 @@ class ToopherTests(unittest.TestCase):
     def test_create_pairing(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'pairings/create':(
-                {'status':'200'},
+            'pairings/create': (200,
                 '{"id":"1", "enabled":true, "user":{"id":"1","name":"some user"}}'
                 )
             })
@@ -66,8 +65,7 @@ class ToopherTests(unittest.TestCase):
     def test_pairing_status(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'pairings/1':(
-                {'status':'200'},
+            'pairings/1': (200,
                 '{"id":"1", "enabled":true, "user":{"id":"1","name":"some user"}}'
                 )
             })
@@ -85,8 +83,7 @@ class ToopherTests(unittest.TestCase):
     def test_create_authentication_request(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'authentication_requests/initiate':(
-                {'status':'200'},
+            'authentication_requests/initiate': (200,
                 '{"id":"1", "pending":false, "granted":true, "automated":false, "reason":"its a test", "terminal":{"id":"1", "name":"test terminal"}}'
                 )
             })
@@ -100,8 +97,7 @@ class ToopherTests(unittest.TestCase):
     def test_authentication_status(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'authentication_requests/1':(
-                {'status':'200'},
+            'authentication_requests/1': (200,
                 '{"id":"1", "pending":false, "granted":true, "automated":false, "reason":"its a test", "terminal":{"id":"1", "name":"test terminal"}}'
                 )
             })
@@ -121,8 +117,7 @@ class ToopherTests(unittest.TestCase):
     def test_pass_arbitrary_parameters_on_pair(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'pairings/create':(
-                {'status':'200'},
+            'pairings/create': (200,
                 '{"id":"1", "enabled":true, "user":{"id":"1","name":"some user"}}'
                 )
             })
@@ -135,8 +130,7 @@ class ToopherTests(unittest.TestCase):
     def test_pass_arbitrary_parameters_on_authenticate(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'authentication_requests/initiate':(
-                {'status':'200'},
+            'authentication_requests/initiate': (200,
                 '{"id":"1", "pending":false, "granted":true, "automated":false, "reason":"its a test", "terminal":{"id":"1", "name":"test terminal"}}'
                 )
             })
@@ -149,8 +143,7 @@ class ToopherTests(unittest.TestCase):
     def test_access_arbitrary_keys_in_pairing_status(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'pairings/1':(
-                {'status':'200'},
+            'pairings/1': (200,
                 '{"id":"1", "enabled":true, "user":{"id":"1","name":"some user"}, "random_key":"84"}'
                 )
             })
@@ -167,8 +160,7 @@ class ToopherTests(unittest.TestCase):
     def test_access_arbitrary_keys_in_authentication_status(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'authentication_requests/1':(
-                {'status':'200'},
+            'authentication_requests/1': (200,
                 '{"id":"1", "pending":false, "granted":true, "automated":false, "reason":"its a test", "terminal":{"id":"1", "name":"test terminal"}, "random_key":"84"}'
                 )
             })
@@ -187,50 +179,50 @@ class ToopherTests(unittest.TestCase):
     def test_disabled_user_raises_correct_error(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'authentication_requests/initiate':
-                ({'status': 409}, json.dumps(
-                    {'error_code': 704,
-                     'error_message': 'disabled user'}))})
+            'authentication_requests/initiate': (409,
+                json.dumps({'error_code': 704,
+                            'error_message': 'disabled user'}))})
+
         with self.assertRaises(toopher.UserDisabledError):
             auth_request = api.authenticate_by_user_name('disabled user', 'terminal name')
 
     def test_unknown_user_raises_correct_error(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'authentication_requests/initiate':
-                ({'status': 409}, json.dumps(
-                    {'error_code': 705,
-                     'error_message': 'unknown user'}))})
+            'authentication_requests/initiate': (409,
+                json.dumps({'error_code': 705,
+                             'error_message': 'unknown user'}))})
+
         with self.assertRaises(toopher.UserUnknownError):
             auth_request = api.authenticate_by_user_name('unknown user', 'terminal name')
 
     def test_unknown_terminal_raises_correct_error(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'authentication_requests/initiate':
-                ({'status': 409}, json.dumps(
-                    {'error_code': 706,
-                     'error_message': 'unknown terminal'}))})
+            'authentication_requests/initiate': (409,
+                json.dumps({'error_code': 706,
+                            'error_message': 'unknown terminal'}))})
+
         with self.assertRaises(toopher.TerminalUnknownError):
             auth_request = api.authenticate_by_user_name('user', 'unknown terminal name')
 
     def test_deactivated_pairing_raises_correct_error(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'authentication_requests/initiate':
-                ({'status': 409}, json.dumps(
-                    {'error_code': 601,
-                     'error_message': 'pairing has been deactivated'}))})
+            'authentication_requests/initiate': (409,
+                json.dumps({'error_code': 601,
+                            'error_message': 'pairing has been deactivated'}))})
+
         with self.assertRaises(toopher.PairingDeactivatedError):
             auth_request = api.authenticate_by_user_name('user', 'terminal name')
 
     def test_unauthorized_pairing_raises_correct_error(self):
         api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'authentication_requests/initiate':
-                ({'status': 409}, json.dumps(
-                    {'error_code': 601,
-                     'error_message': 'pairing has not been authorized'}))})
+            'authentication_requests/initiate': (409,
+                json.dumps({'error_code': 601,
+                            'error_message': 'pairing has not been authorized'}))})
+
         with self.assertRaises(toopher.PairingDeactivatedError):
             auth_request = api.authenticate_by_user_name('user', 'terminal name')
 

--- a/tests.py
+++ b/tests.py
@@ -221,7 +221,7 @@ class ToopherTests(unittest.TestCase):
         with self.assertRaises(toopher.PairingDeactivatedError):
             auth_request = api.authenticate_by_user_name('user', 'terminal name')
 
-    def test_disabled_pairing_raises_correct_error(self):
+    def test_unauthorized_pairing_raises_correct_error(self):
         api = toopher.ToopherApi('key', 'secret', api_url='https://toopher.test/v1')
         api.client = HttpClientMock({
             'https://toopher.test/v1/authentication_requests/initiate':

--- a/tests.py
+++ b/tests.py
@@ -253,6 +253,22 @@ class AuthenticationStatusTests(unittest.TestCase):
         denied = toopher.AuthenticationStatus(response)
         self.assertFalse(denied)
 
+class PairingStatusTests(unittest.TestCase):
+    def test_incomplete_response_raises_exception(self):
+        response = {'key': 'value'}
+        with self.assertRaises(toopher.ToopherApiError):
+            toopher.PairingStatus(response)
+
+    def test_nonzero_when_granted(self):
+        response = ddict()
+        response['enabled'] = True
+        allowed = toopher.PairingStatus(response)
+        self.assertTrue(allowed)
+
+        response['enabled'] = False
+        denied = toopher.PairingStatus(response)
+        self.assertFalse(denied)
+
 def main():
     unittest.main()
 

--- a/tests.py
+++ b/tests.py
@@ -251,11 +251,11 @@ class ZeroStorageTests(unittest.TestCase):
 
         api.set_toopher_enabled_for_user('user_name', True)
         self.assertEqual(api.client.last_called_method, 'POST')
-        self.assertTrue(api.client.last_called_data['disable_toopher_auth'])
+        self.assertFalse(api.client.last_called_data['disable_toopher_auth'])
 
         api.set_toopher_enabled_for_user('user_name', False)
         self.assertEqual(api.client.last_called_method, 'POST')
-        self.assertFalse(api.client.last_called_data['disable_toopher_auth'])
+        self.assertTrue(api.client.last_called_data['disable_toopher_auth'])
 
     def test_enable_toopher_multiple_users(self):
         api = toopher.ToopherApi('key', 'secret')

--- a/tests.py
+++ b/tests.py
@@ -13,6 +13,7 @@ class HttpClientMock(object):
         self.last_called_data = data if data else params
         self.last_called_headers = headers
 
+        uri = uri.split(toopher.DEFAULT_BASE_URL)[1][1:]
         if uri in self.paths:
             return ResponseMock(self.paths[uri])
         else:
@@ -25,11 +26,13 @@ class ResponseMock(requests.Response):
         self._content = response[1]
 
 class ToopherTests(unittest.TestCase):
+    toopher.DEFAULT_BASE_URL = 'https://api.toopher.test/v1'
+
     def test_constructor(self):
         with self.assertRaises(TypeError):
             api = toopher.ToopherApi()
 
-        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api = toopher.ToopherApi('key', 'secret')
 
     def test_version_number_in_library(self):
         major, minor, patch = toopher.VERSION.split('.')
@@ -46,9 +49,9 @@ class ToopherTests(unittest.TestCase):
                 self.assertEqual(version_number, toopher.VERSION)
 
     def test_create_pairing(self):
-        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'http://testonly/pairings/create':(
+            'pairings/create':(
                 {'status':'200'},
                 '{"id":"1", "enabled":true, "user":{"id":"1","name":"some user"}}'
                 )
@@ -61,9 +64,9 @@ class ToopherTests(unittest.TestCase):
             self.assertEqual(api.client.last_called_data['test_param'], ['42'])
 
     def test_pairing_status(self):
-        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'http://testonly/pairings/1':(
+            'pairings/1':(
                 {'status':'200'},
                 '{"id":"1", "enabled":true, "user":{"id":"1","name":"some user"}}'
                 )
@@ -80,9 +83,9 @@ class ToopherTests(unittest.TestCase):
             foo = pairing.random_key
 
     def test_create_authentication_request(self):
-        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'http://testonly/authentication_requests/initiate':(
+            'authentication_requests/initiate':(
                 {'status':'200'},
                 '{"id":"1", "pending":false, "granted":true, "automated":false, "reason":"its a test", "terminal":{"id":"1", "name":"test terminal"}}'
                 )
@@ -95,9 +98,9 @@ class ToopherTests(unittest.TestCase):
             self.assertEqual(api.client.last_called_data['test_param'], '42')
 
     def test_authentication_status(self):
-        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'http://testonly/authentication_requests/1':(
+            'authentication_requests/1':(
                 {'status':'200'},
                 '{"id":"1", "pending":false, "granted":true, "automated":false, "reason":"its a test", "terminal":{"id":"1", "name":"test terminal"}}'
                 )
@@ -116,9 +119,9 @@ class ToopherTests(unittest.TestCase):
             foo = auth_request.random_key
 
     def test_pass_arbitrary_parameters_on_pair(self):
-        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'http://testonly/pairings/create':(
+            'pairings/create':(
                 {'status':'200'},
                 '{"id":"1", "enabled":true, "user":{"id":"1","name":"some user"}}'
                 )
@@ -130,9 +133,9 @@ class ToopherTests(unittest.TestCase):
         self.assertEqual(api.client.last_called_data['test_param'], '42')
 
     def test_pass_arbitrary_parameters_on_authenticate(self):
-        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'http://testonly/authentication_requests/initiate':(
+            'authentication_requests/initiate':(
                 {'status':'200'},
                 '{"id":"1", "pending":false, "granted":true, "automated":false, "reason":"its a test", "terminal":{"id":"1", "name":"test terminal"}}'
                 )
@@ -144,9 +147,9 @@ class ToopherTests(unittest.TestCase):
         self.assertEqual(api.client.last_called_data['test_param'], '42')
 
     def test_access_arbitrary_keys_in_pairing_status(self):
-        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'http://testonly/pairings/1':(
+            'pairings/1':(
                 {'status':'200'},
                 '{"id":"1", "enabled":true, "user":{"id":"1","name":"some user"}, "random_key":"84"}'
                 )
@@ -162,9 +165,9 @@ class ToopherTests(unittest.TestCase):
         self.assertEqual(pairing.random_key, "84")
 
     def test_access_arbitrary_keys_in_authentication_status(self):
-        api = toopher.ToopherApi('key', 'secret', api_url='http://testonly')
+        api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'http://testonly/authentication_requests/1':(
+            'authentication_requests/1':(
                 {'status':'200'},
                 '{"id":"1", "pending":false, "granted":true, "automated":false, "reason":"its a test", "terminal":{"id":"1", "name":"test terminal"}, "random_key":"84"}'
                 )
@@ -182,9 +185,9 @@ class ToopherTests(unittest.TestCase):
         self.assertEqual(auth_request.random_key, "84")
 
     def test_disabled_user_raises_correct_error(self):
-        api = toopher.ToopherApi('key', 'secret', api_url='https://toopher.test/v1')
+        api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'https://toopher.test/v1/authentication_requests/initiate':
+            'authentication_requests/initiate':
                 ({'status': 409}, json.dumps(
                     {'error_code': 704,
                      'error_message': 'disabled user'}))})
@@ -192,9 +195,9 @@ class ToopherTests(unittest.TestCase):
             auth_request = api.authenticate_by_user_name('disabled user', 'terminal name')
 
     def test_unknown_user_raises_correct_error(self):
-        api = toopher.ToopherApi('key', 'secret', api_url='https://toopher.test/v1')
+        api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'https://toopher.test/v1/authentication_requests/initiate':
+            'authentication_requests/initiate':
                 ({'status': 409}, json.dumps(
                     {'error_code': 705,
                      'error_message': 'unknown user'}))})
@@ -202,19 +205,19 @@ class ToopherTests(unittest.TestCase):
             auth_request = api.authenticate_by_user_name('unknown user', 'terminal name')
 
     def test_unknown_terminal_raises_correct_error(self):
-        api = toopher.ToopherApi('key', 'secret', api_url='https://toopher.test/v1')
+        api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'https://toopher.test/v1/authentication_requests/initiate':
+            'authentication_requests/initiate':
                 ({'status': 409}, json.dumps(
                     {'error_code': 706,
                      'error_message': 'unknown terminal'}))})
         with self.assertRaises(toopher.TerminalUnknownError):
             auth_request = api.authenticate_by_user_name('user', 'unknown terminal name')
 
-    def test_disabled_pairing_raises_correct_error(self):
-        api = toopher.ToopherApi('key', 'secret', api_url='https://toopher.test/v1')
+    def test_deactivated_pairing_raises_correct_error(self):
+        api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'https://toopher.test/v1/authentication_requests/initiate':
+            'authentication_requests/initiate':
                 ({'status': 409}, json.dumps(
                     {'error_code': 601,
                      'error_message': 'pairing has been deactivated'}))})
@@ -222,9 +225,9 @@ class ToopherTests(unittest.TestCase):
             auth_request = api.authenticate_by_user_name('user', 'terminal name')
 
     def test_unauthorized_pairing_raises_correct_error(self):
-        api = toopher.ToopherApi('key', 'secret', api_url='https://toopher.test/v1')
+        api = toopher.ToopherApi('key', 'secret')
         api.client = HttpClientMock({
-            'https://toopher.test/v1/authentication_requests/initiate':
+            'authentication_requests/initiate':
                 ({'status': 409}, json.dumps(
                     {'error_code': 601,
                      'error_message': 'pairing has not been authorized'}))})

--- a/tests.py
+++ b/tests.py
@@ -226,6 +226,13 @@ class ToopherTests(unittest.TestCase):
         with self.assertRaises(toopher.PairingDeactivatedError):
             auth_request = api.authenticate_by_user_name('user', 'terminal name')
 
+class ZeroStorageTests(unittest.TestCase):
+    def test_create_user_terminal(self):
+        api = toopher.ToopherApi('key', 'secret')
+        api.client = HttpClientMock({'user_terminals/create': (200, '{}')})
+
+        api.create_user_terminal('user_name', 'terminal_name', 'requester_terminal_id')
+
 class ddict(dict):
     def __getitem__(self, key):
         try:

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -4,7 +4,7 @@ import oauth2
 import os
 import sys
 DEFAULT_BASE_URL = "https://api.toopher.com/v1"
-VERSION = "1.0.6"
+VERSION = '1.1.0'
 
 class ToopherApiError(Exception): pass
 class UserDisabledError(ToopherApiError): pass
@@ -84,7 +84,7 @@ class ToopherApi(object):
                   'name_extra': requester_terminal_id}
         result = self._request(uri, 'POST', params)
 
-    def set_enable_toopher_for_user(self, user_name, enabled):
+    def set_toopher_enabled_for_user(self, user_name, enabled):
         uri = self.base_url + '/users'
         users = self._request(uri, 'GET')
         if len(users) > 1:
@@ -106,7 +106,7 @@ class ToopherApi(object):
         except ValueError:
             raise ToopherApiError('Response from server could not be decoded as JSON.')
 
-        if int(response['status']) > 300:
+        if int(response['status']) >= 400:
             self._parse_request_error(content)
 
         return content

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -1,4 +1,3 @@
-import json
 import os
 import requests_oauthlib
 import sys
@@ -84,7 +83,7 @@ class ToopherApi(object):
         params = {'user_name': user_name,
                   'name': terminal_name,
                   'name_extra': requester_terminal_id}
-        result = self._request(uri, 'POST', params)
+        self._request(uri, 'POST', params)
 
     def set_toopher_enabled_for_user(self, user_name, enabled):
         uri = self.base_url + '/users'
@@ -92,13 +91,13 @@ class ToopherApi(object):
         users = self._request(uri, 'GET', params)
 
         if len(users) > 1:
-            raise ToopherApiException('Multiple users with name = {}'.format(user_name))
+            raise ToopherApiError('Multiple users with name = {}'.format(user_name))
         elif not len(users):
-            raise ToopherApiException('No users with name = {}'.format(user_name))
+            raise ToopherApiError('No users with name = {}'.format(user_name))
 
         uri = self.base_url + '/users/' + users[0]['id']
         params = {'disable_toopher_auth': bool(enabled)}
-        result = self._request(uri, 'POST', params)
+        self._request(uri, 'POST', params)
 
     def _request(self, uri, method, params=None):
         data = {'params' if method == 'GET' else 'data': params}

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -96,7 +96,7 @@ class ToopherApi(object):
             raise ToopherApiError('No users with name = {}'.format(user_name))
 
         uri = self.base_url + '/users/' + users[0]['id']
-        params = {'disable_toopher_auth': bool(enabled)}
+        params = {'disable_toopher_auth': not enabled}
         self._request(uri, 'POST', params)
 
     def _request(self, uri, method, params=None):


### PR DESCRIPTION
This pull request brings to life @smholloway's feedback on PR #16.

**Edit:** This pull request replaces python-oauth2 and it's gross `/(http|url)lib\d?/` cohorts with the excellent [Requests](http://www.python-requests.org/en/latest/) library. It also brings in [nose](http://nose.readthedocs.org/en/latest/) for running tests and [coverage](http://nedbatchelder.com/code/coverage/), which says that this pull request improves test coverage from ~85% to 100%.

Try it yourself: `nosetests --with-coverage --cover-package=toopher`
