### PR TITLE
Fix __getattr__ implementation to raise correct exception

### DIFF
--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -145,7 +145,10 @@ class PairingStatus(object):
         return self.enabled
 
     def __getattr__(self, name):
-        return self._raw_data[name]
+        try:
+            return self._raw_data[name]
+        except KeyError:
+            raise AttributeError(name)
 
 
 class AuthenticationStatus(object):
@@ -169,4 +172,10 @@ class AuthenticationStatus(object):
         return self.granted
 
     def __getattr__(self, name):
-        return self._raw_data[name]
+        try:
+            return self._raw_data[name]
+        except KeyError:
+            raise AttributeError(name)
+
+
+class ToopherApiError(Exception): pass


### PR DESCRIPTION
If an unknown attribute name access was attempted on `PairingStatus` or `AuthenticationStatus` objects they would raise a KeyError instead of an AttributeError.  This breach of contract breaks things like pickling - so this commit fixes that.

This is an informational PR - I don't expect anyone to complain about it so I'll be merging immediately.
