### PR TITLE
Switch to using the new `web/authenticate` endpoint

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -67,7 +67,7 @@ class ToopherIframeTests(unittest.TestCase):
         self.assertEqual(expected, self.iframe_api.pair_uri('jdoe', 'jdoe@example.com'))
 
     def test_get_login_uri(self):
-        expected = 'https://api.toopher.test/v1/web/auth?username=jdoe&automation_allowed=True&reset_email=jdoe%40example.com&session_token=s9s7vsb&v=2&requester_metadata=None&challenge_required=False&expires=1100&action_name=Log+In&oauth_nonce=12345678&oauth_timestamp=1000&oauth_version=1.0&oauth_signature_method=HMAC-SHA1&oauth_consumer_key=abcdefg&oauth_signature=bpgdxhHLDwpYsbru%2Bnz2p9pFlr4%3D'
+        expected = 'https://api.toopher.test/v1/web/authenticate?username=jdoe&automation_allowed=True&reset_email=jdoe%40example.com&session_token=s9s7vsb&v=2&requester_metadata=None&challenge_required=False&expires=1100&action_name=Log+In&oauth_nonce=12345678&oauth_timestamp=1000&oauth_version=1.0&oauth_signature_method=HMAC-SHA1&oauth_consumer_key=abcdefg&oauth_signature=PykRbVHUP2OTTjGF0GJaS5TTu54%3D'
         self.assertEqual(expected, self.iframe_api.login_uri('jdoe', 'jdoe@example.com', ToopherIframeTests.request_token))
 
 

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -58,7 +58,7 @@ class ToopherIframe(object):
                 'session_token':request_token,
                 'requester_metadata':requester_metadata
                 }
-        return self.get_oauth_uri(self.base_uri + '/web/auth', params, ttl)
+        return self.get_oauth_uri(self.base_uri + '/web/authenticate', params, ttl)
 
     def login_uri(self, username, reset_email, request_token):
         return self.auth_uri(username, reset_email, 'Log In', True, False, request_token, 'None', DEFAULT_IFRAME_TTL)


### PR DESCRIPTION
This PR prepares for the API changes by providing a simple, sane default. The web/auth endpoint is being deprecated in favor of the new all-in-one iframe at web/authenticate.
