### PR TITLE
add helper method for manage_user iframe endpoint

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -79,6 +79,10 @@ class ToopherIframeTests(unittest.TestCase):
         expected = 'https://api.toopher.test/v1/web/pair?username=jdoe&reset_email=jdoe%40example.com&expires=1100&v=2&oauth_nonce=12345678&oauth_timestamp=1000&oauth_version=1.0&oauth_signature_method=HMAC-SHA1&oauth_consumer_key=abcdefg&oauth_signature=UGlgBEUF6UZEhYPxevJeagqy6D4%3D'
         self.assertEqual(expected, self.iframe_api.pair_uri('jdoe', 'jdoe@example.com'))
 
+    def test_get_manage_user_uri(self):
+        expected = 'https://api.toopher.test/v1/web/manage_user?username=jdoe&reset_email=jdoe%40example.com&expires=1100&v=2&oauth_nonce=12345678&oauth_timestamp=1000&oauth_version=1.0&oauth_signature_method=HMAC-SHA1&oauth_consumer_key=abcdefg&oauth_signature=sV8qoKnxJ3fxfP6AHNa0eNFxzJs%3D'
+        self.assertEqual(expected, self.iframe_api.manage_user_uri('jdoe', 'jdoe@example.com'))
+
     def test_get_login_uri(self):
         expected = 'https://api.toopher.test/v1/web/authenticate?username=jdoe&automation_allowed=True&reset_email=jdoe%40example.com&session_token=s9s7vsb&v=2&requester_metadata=None&challenge_required=False&expires=1100&action_name=Log+In&oauth_nonce=12345678&oauth_timestamp=1000&oauth_version=1.0&oauth_signature_method=HMAC-SHA1&oauth_consumer_key=abcdefg&oauth_signature=PykRbVHUP2OTTjGF0GJaS5TTu54%3D'
         self.assertEqual(expected, self.iframe_api.login_uri('jdoe', 'jdoe@example.com', ToopherIframeTests.request_token))

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -47,6 +47,14 @@ class ToopherIframe(object):
                 }
         return self.get_oauth_uri(self.base_uri + '/web/pair', params, ttl)
 
+    def manage_user_uri(self, username, reset_email, ttl = DEFAULT_IFRAME_TTL):
+        params = {
+                'v':IFRAME_VERSION,
+                'username':username,
+                'reset_email':reset_email
+                }
+        return self.get_oauth_uri(self.base_uri + '/web/manage_user', params, ttl)
+
     def auth_uri(self, username, reset_email, action_name, automation_allowed, challenge_required, request_token, requester_metadata, ttl=DEFAULT_IFRAME_TTL):
         params = {
                 'v':IFRAME_VERSION,

--- a/toopher/__init__.py
+++ b/toopher/__init__.py
@@ -47,7 +47,7 @@ class ToopherIframe(object):
                 }
         return self.get_oauth_uri(self.base_uri + '/web/pair', params, ttl)
 
-    def manage_user_uri(self, username, reset_email, ttl = DEFAULT_IFRAME_TTL):
+    def manage_user_uri(self, username, reset_email, ttl=DEFAULT_IFRAME_TTL):
         params = {
                 'v':IFRAME_VERSION,
                 'username':username,


### PR DESCRIPTION
Adds support for `manage_user` iframe endpoint, which allows the user to pregenerate backup OTPs for authentication.
